### PR TITLE
Upgrade dependabot to v2.0

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,7 +1,0 @@
-version: 1
-update_configs:
-  # Keep package.json (& lockfiles) secure and up-to-date,
-  # batching pull requests daily
-  - package_manager: "javascript"
-    directory: "/"
-    update_schedule: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Basic dependabot.yml file with
+# minimum configuration for two package managers
+
+version: 2
+updates:
+  # Enable version updates for npm
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `lock` files in the `root` directory
+    directory: "/"
+    # Check the npm registry for updates every day (weekdays)
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
- Previously v1.0 and it is located in the incorrect folder.